### PR TITLE
update to golang 1.12

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -20,4 +20,4 @@
 # GOPATH and handle all of the Go ENV stuff for you.  All you need is Docker
 docker run -it -v "$PWD":/go/src/k8s.io/cloud-provider-openstack:z \
 	-w /go/src/k8s.io/cloud-provider-openstack \
-	golang:1.10 make $1
+	golang:1.12 make $1


### PR DESCRIPTION
**What this PR does / why we need it**:

The Docker based build still references the golang:1.10 build container. The code references variables in `crypto/tls` that are only available stating with golang:1.12.

**Special notes for your reviewer**:

**Release note**:
```release-note
Update Docker build to use Golang 1.12
```
